### PR TITLE
메인 페이지에 출력할 데이터가 없을 경우의 화면을 구현했습니다.

### DIFF
--- a/front/src/pages/MainPage.tsx
+++ b/front/src/pages/MainPage.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styled, { keyframes } from "styled-components";
-import { RecomShorts, Shorts } from "../constants/types";
-import { getRecommendedShorts, getShortsList, getTopRankingShorts, getTryCount } from "../apis/shorts";
+import { CancelPresentation, Copyright, EmojiPeople, MusicNote, TimerOutlined } from "@mui/icons-material";
+
 import Header from "../components/header/Header";
 import ShortsVideoItem from "../components/shorts/ShortsVideoItem";
-import { CancelPresentation, Copyright, EmojiPeople, MusicNote, TimerOutlined } from "@mui/icons-material";
+import { RecomShorts, Shorts } from "../constants/types";
+import { getRecommendedShorts, getShortsList, getTopRankingShorts, getTryCount } from "../apis/shorts";
 
 const MainPage = () => {
   const navigate = useNavigate();
@@ -81,7 +82,7 @@ const MainPage = () => {
               <p>당신이 좋아할 만한 챌린지를 추천해드릴게요.</p>
             </SectionHeaderContainer>
             <SectionConents className="nowrap">
-              {recommendedShorts?.map(shorts => (
+              {recommendedShorts.map(shorts => (
                 <ShortsVideoItem
                   key={shorts.shortsNo}
                   shortsInfo={shorts}


### PR DESCRIPTION
## 요약
1. 추천 쇼츠 리스트와 인기 쇼츠 리스트는 데이터를 가져오지 못하는 경우, 해당 컨텐츠 섹션을 화면에 출력하지 않습니다.

2. MainPage.tsx의 리팩토링을 진행했습니다.
    - 상단 import 순서 조정

## 왜 컨텐츠를 가리는가
기존의 생각은 데이터가 없을 경우, 컨텐츠를 찾을 수 없다는 오류 문구를 내보낼 예정이었습니다. 그러나 이러한 문구가 반복되면 화면이 복잡하고, 신뢰도가 떨어질 수 있다고 판단했습니다.
그래서 아예 오류가 난 부분을 사용자에게 보여주지 않는게 좋겠다고 생각했습니다. 이러한 생각이 가능한 이유는 추천과 인기 쇼츠 리스트는 아주 중대한 컨텐츠는 아니기 때문입니다.

우리의 메인 컨텐츠인 '둘러보기'는 매우 중요하기 때문에 데이터를 불러올 수 없을 경우, 스켈레톤 또는 스피닝 로딩 등 로딩 화면을 보여줘야 한다고 생각합니다.

## 다음 계획
1. 메인 페이지에서 몇몇의 동영상이 나오지 않는 오류를 해결

2. 둘러보기를 무한 스크롤로 구현
    - 쇼츠 목록 조회(/api/shorts)의 수정이 필요할 수 있음

3. 동영상 목록의 UI/UX 업그레이드
    - 커서의 모양, 상호작용 등등

4. 메인 페이지 입장 시간 단축
   - 현재 동영상 자체를 로드하도록 구현한 것이 그 이유라고 생각함
   - 리스트를 썸네일로 보여주도록 수정한다면?
   - 재생 버튼을 삭제하고 동영상 썸네일을 가져다대면 동영상이 재생하도록 한다면?