### PR TITLE
페이지별 쇼츠 목록 조회 API를 추가했습니다.

### DIFF
--- a/back/sleep/src/main/java/com/sleep/sleep/shorts/controller/ShortsController.java
+++ b/back/sleep/src/main/java/com/sleep/sleep/shorts/controller/ShortsController.java
@@ -1,6 +1,7 @@
 package com.sleep.sleep.shorts.controller;
 
 import com.sleep.sleep.common.JWT.JwtTokenUtil;
+import com.sleep.sleep.shorts.dto.PagenationShortsDto;
 import com.sleep.sleep.shorts.dto.ShortsDto;
 import com.sleep.sleep.shorts.dto.UploadShortsDto;
 import com.sleep.sleep.shorts.entity.UploadShorts;
@@ -13,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -33,6 +35,14 @@ public class ShortsController {
         List<ShortsDto> shortsList = shortsService.getShortList();
 
         return ResponseEntity.ok(shortsList);
+    }
+
+    @Operation(summary = "페이지별 쇼츠 목록 조회")
+    @GetMapping("page/{page}")
+    public ResponseEntity<PagenationShortsDto> selectShortList(@PathVariable int page) {
+        PagenationShortsDto result = shortsService.getShortList(page, 10);
+        if (result.getContents() == null) result.setContents(new ArrayList<>());
+        return ResponseEntity.ok(result);
     }
 
     @Operation(summary = "특정 쇼츠 조회")

--- a/back/sleep/src/main/java/com/sleep/sleep/shorts/dto/PagenationShortsDto.java
+++ b/back/sleep/src/main/java/com/sleep/sleep/shorts/dto/PagenationShortsDto.java
@@ -1,0 +1,15 @@
+package com.sleep.sleep.shorts.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PagenationShortsDto {
+    private List<ShortsDto> contents;
+    private boolean isLastPage;
+}

--- a/back/sleep/src/main/java/com/sleep/sleep/shorts/service/ShortsService.java
+++ b/back/sleep/src/main/java/com/sleep/sleep/shorts/service/ShortsService.java
@@ -1,5 +1,6 @@
 package com.sleep.sleep.shorts.service;
 
+import com.sleep.sleep.shorts.dto.PagenationShortsDto;
 import com.sleep.sleep.shorts.dto.ShortsDto;
 import com.sleep.sleep.shorts.dto.TryShortsDto;
 import com.sleep.sleep.shorts.dto.UploadShortsDto;
@@ -8,12 +9,16 @@ public interface ShortsService {
 
     //특정 쇼츠 조회
     public ShortsDto getShortsInfo(int shortsNo);
-    //리스트 조회
-     public List<ShortsDto> getShortList();
-     public List<ShortsDto> getShortRankingList();
 
-     //사용자의 업로드한 쇼츠 리스트
-     public List<UploadShortsDto> getUploadShortsList(String memberId);
+    //리스트 조회
+    public List<ShortsDto> getShortList();
+    public List<ShortsDto> getShortRankingList();
+
+    // 페이지별 쇼츠 리스트 조회
+    public PagenationShortsDto getShortList(int page, int size);
+
+    //사용자의 업로드한 쇼츠 리스트
+    public List<UploadShortsDto> getUploadShortsList(String memberId);
 
      //사용자가 업로드한 영상 DB에 넣기
     public void upload(UploadShortsDto dto,String username);

--- a/back/sleep/src/main/java/com/sleep/sleep/shorts/service/ShortsServiceImpl.java
+++ b/back/sleep/src/main/java/com/sleep/sleep/shorts/service/ShortsServiceImpl.java
@@ -4,6 +4,7 @@ import com.sleep.sleep.member.dto.JoinDto;
 import com.sleep.sleep.member.entity.Member;
 import com.sleep.sleep.member.entity.MemberRole;
 import com.sleep.sleep.member.repository.MemberRepository;
+import com.sleep.sleep.shorts.dto.PagenationShortsDto;
 import com.sleep.sleep.shorts.dto.ShortsDto;
 import com.sleep.sleep.shorts.dto.TryShortsDto;
 import com.sleep.sleep.shorts.dto.UploadShortsDto;
@@ -63,6 +64,57 @@ public class ShortsServiceImpl implements ShortsService{
         return shortsInfo;
     }
 
+    /**
+     * 페이지별 쇼츠 리스트 조회
+     * @param page 조회하고 싶은 페이지 번호
+     * @param size 한 페이지 안의 콘텐츠 크기
+     * @return 한 페이지 범위의 Shorts 리스트를 담은 PagenationShortsDto
+     */
+    public PagenationShortsDto getShortList(int page, int size) {
+        List<Shorts> shorts = shortsRepository.findShortList();
+
+        PagenationShortsDto result = new PagenationShortsDto();
+        List<ShortsDto> shortsList = new ArrayList<>();
+
+        int start = page * size;            // 조회 시작 범위
+        int end = (page + 1) * size - 1;    // 조회 끝 범위
+        boolean isLastPage = false;
+
+        // 끝 범위가 리스트 범위를 벗어나면 끝 범위를 마지막 인덱스로 설정한다.
+        if (end >= shorts.size()) {
+            end = shorts.size() - 1;
+            isLastPage = true;
+        }
+
+        // 범위에 있는 Shorts 정보들을 shortsList에 저장한다.
+        for(int i = start; i <= end; i++){
+            Shorts value = shorts.get(i);
+            ShortsDto shortsDto = new ShortsDto();
+
+            shortsDto.setShortsNo(value.getShortsNo());
+            shortsDto.setShortsUrl(value.getShortsUrl());
+            shortsDto.setShortsTime(value.getShortsTime());
+            shortsDto.setShortsTitle(value.getShortsTitle());
+            shortsDto.setShortsDirector(value.getShortsDirector());
+            shortsDto.setShortsChallengers(value.getShortsChallengers());
+            shortsDto.setShortsLink(value.getShortsLink());
+            shortsDto.setShortDate(value.getShortsDate());
+
+            int musicNo = value.getMusicNo();
+            Music music = musicRepository.findByMusicNo(musicNo);
+            MusicSinger musicSinger= musicSingerRepository.findByMusicNo(musicNo);
+            Singer singer = singerRepository.findBySingerNo(musicSinger.getSingerNo());
+            shortsDto.setMusicName(music.getMusicName());
+            shortsDto.setSingerName(singer.getSingerName());
+
+            shortsList.add(shortsDto);
+        }
+
+        result.setContents(shortsList);
+        result.setLastPage(isLastPage);
+
+        return result;
+    }
 
     //리스트 조회
     public List<ShortsDto> getShortList() {


### PR DESCRIPTION
## 설명
GET /api/shorts/page/{page}
페이지별 쇼츠 목록을 조회합니다.
한 페이지 당 10개의 크기로 출력하도록 기본값을 설정했습니다. (따로 파라미터를 받지 않고 있으며, 바꾸고 싶다면 코드 내에서 수정이 필요합니다.)

## 반환값
`List<ShortsDto> contents` : 해당 페이지의 콘텐츠 리스트
`boolean isLastPage` : 현재 페이지가 마지막 페이지인지 반환

PageniationShortsDto는 이후 다른 곳에서 페이지네이션이 필요할 경우 재사용이 가능할 것 같습니다.