### PR TITLE
메인페이지에서 영상에 마우스를 갖다 대면 영상이 재생되는 기능을 추가했습니다.

### DIFF
--- a/front/src/GlobalStyle.tsx
+++ b/front/src/GlobalStyle.tsx
@@ -12,7 +12,6 @@ const GlobalStyle = createGlobalStyle`
     box-sizing: border-box;
   }
 
-
   :root {
     --grid-item-max-width: 500px;
     --grid-item-min-width: 310px;
@@ -20,24 +19,24 @@ const GlobalStyle = createGlobalStyle`
     --grid-item-margin: 12px;
 
     @media screen and (min-width: 600px) {
-      --grid-items-per-row: 3;
+      --grid-items-per-row: 2;
       --grid-item-margin: 16px;
     }
 
     @media screen and (min-width: 740px) {
-      --grid-items-per-row: 4;
+      --grid-items-per-row: 3;
       --grid-item-margin: 18px;
     }
 
     @media screen and (min-width: 1024px) {
-      --grid-items-per-row: 5;
+      --grid-items-per-row: 4;
       --grid-item-margin: 20px;
     }
   }
 
   body {
-  font-family: "Noto Sans KR", sans-serif;
-}
+    font-family: "Noto Sans KR", sans-serif;
+  }
 
   a {
     text-decoration: none;

--- a/front/src/components/shorts/ShortsCard.tsx
+++ b/front/src/components/shorts/ShortsCard.tsx
@@ -19,22 +19,21 @@ interface ShortsCardProps {
 }
 
 const ShortsCard = ({ shortsInfo }: ShortsCardProps) => {
-  // mute를 store에서 통합 관리해서 다른 곳에서 음소거를 해제하면 계속 유지
   const { isMuted, toggleMute } = useShortsVideoStore();
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const videoRef = useRef<HTMLVideoElement>(null);
 
-  const handleClick = () => {
+  const openModal = () => {
     pauseVideo();
     alert("모달이 열립니다.");
   };
 
-  // 영상에 마우스 올리면 재생
-  const hanldeMouseEnter = () => {
+  // 영상에 마우스가 들어오면 영상 재생을 시작한다.
+  const playVideo = () => {
     videoRef.current?.play();
   };
 
-  // 마우스를 떼면 0초로 돌아가는 기능 추가
+  // 영상에서 마우스를 떼면 재생된 영상을 초기화한다.
   const pauseVideo = () => {
     const video = videoRef.current;
     if (video) {
@@ -44,10 +43,10 @@ const ShortsCard = ({ shortsInfo }: ShortsCardProps) => {
   };
 
   return (
-    <Card onMouseEnter={hanldeMouseEnter} onMouseLeave={pauseVideo}>
+    <Card onMouseEnter={playVideo} onMouseLeave={pauseVideo}>
       {isLoading && <CardVideoSkeleton />}
       <CardVideoContainer>
-        <div onClick={handleClick}>
+        <div onClick={openModal}>
           <CardVideo
             muted={isMuted}
             src={shortsInfo.shortsLink}
@@ -62,7 +61,7 @@ const ShortsCard = ({ shortsInfo }: ShortsCardProps) => {
           {isMuted ? <VolumeOffRounded /> : <VolumeUpRounded />}
         </SoundButton>
       </CardVideoContainer>
-      <div onClick={handleClick}>
+      <div onClick={openModal}>
         <CardTitle>{shortsInfo.shortsTitle}</CardTitle>
         <CardSubTitle>챌린저 {shortsInfo.shortsChallengers}명</CardSubTitle>
       </div>

--- a/front/src/components/shorts/ShortsCard.tsx
+++ b/front/src/components/shorts/ShortsCard.tsx
@@ -6,7 +6,7 @@ import {
   Card,
   CardVideo,
   CardTitle,
-  CardSubTitle,
+  CardDesc,
   CardVideoSkeleton,
   CardVideoContainer,
   SoundButton,
@@ -62,7 +62,7 @@ const ShortsCard = ({ shortsInfo }: ShortsCardProps) => {
       </CardVideoContainer>
       <div onClick={openModal}>
         <CardTitle>{shortsInfo.shortsTitle}</CardTitle>
-        <CardSubTitle>챌린저 {shortsInfo.shortsChallengers}명</CardSubTitle>
+        <CardDesc>챌린저 {shortsInfo.shortsChallengers}명</CardDesc>
       </div>
     </Card>
   );

--- a/front/src/components/shorts/ShortsCard.tsx
+++ b/front/src/components/shorts/ShortsCard.tsx
@@ -19,15 +19,23 @@ const ShortsCard = ({ shortsInfo }: ShortsCardProps) => {
   // 근데 사용자 인터렉션 없이 재생하는 거 안 됨
   // mute하면 해결할 수 있다.
   // 이후 mute를 store에서 통합 관리해서 다른 곳에서 음소거를 해제하면 계속 유지되도록 하자.
-  // 마우스를 떼면 0초로 돌아가는 기능도 필요
   // 미리보기는 전체는 아니고 5초 후에 멈추는 걸로 하자.
   const hanldeMouseEnter = () => {
     videoRef.current?.play();
     console.log(shortsInfo.shortsTitle);
   };
 
+  // 마우스를 떼면 0초로 돌아가는 기능 추가
+  const handleMouseLeave = () => {
+    const video = videoRef.current;
+    if (video) {
+      video.pause();
+      video.currentTime = 0;
+    }
+  };
+
   return (
-    <Card onClick={handleClick} onMouseEnter={hanldeMouseEnter}>
+    <Card onClick={handleClick} onMouseEnter={hanldeMouseEnter} onMouseLeave={handleMouseLeave}>
       {isLoading && <CardVideoSkeleton />}
       <CardVideo
         muted

--- a/front/src/components/shorts/ShortsCard.tsx
+++ b/front/src/components/shorts/ShortsCard.tsx
@@ -12,6 +12,7 @@ const ShortsCard = ({ shortsInfo }: ShortsCardProps) => {
   const videoRef = useRef<HTMLVideoElement>(null);
 
   const handleClick = () => {
+    pauseVideo();
     alert("모달이 열립니다.");
   };
 
@@ -22,11 +23,12 @@ const ShortsCard = ({ shortsInfo }: ShortsCardProps) => {
   // 미리보기는 전체는 아니고 5초 후에 멈추는 걸로 하자.
   const hanldeMouseEnter = () => {
     videoRef.current?.play();
-    console.log(shortsInfo.shortsTitle);
   };
 
   // 마우스를 떼면 0초로 돌아가는 기능 추가
-  const handleMouseLeave = () => {
+  const handleMouseLeave = () => pauseVideo();
+
+  const pauseVideo = () => {
     const video = videoRef.current;
     if (video) {
       video.pause();

--- a/front/src/components/shorts/ShortsCard.tsx
+++ b/front/src/components/shorts/ShortsCard.tsx
@@ -1,6 +1,17 @@
 import { useRef, useState } from "react";
+import { VolumeUpRounded, VolumeOffRounded } from "@mui/icons-material";
 
-import { Card, CardVideo, CardTitle, CardSubTitle, CardVideoSkeleton } from "./style";
+import useShortsVideoStore from "../../store/useShortsVideoStore";
+import {
+  Card,
+  CardVideo,
+  CardTitle,
+  CardSubTitle,
+  CardVideoSkeleton,
+  CardVideoContainer,
+  SoundButton,
+  Gradient,
+} from "./style";
 import { Shorts } from "../../constants/types";
 
 interface ShortsCardProps {
@@ -8,6 +19,8 @@ interface ShortsCardProps {
 }
 
 const ShortsCard = ({ shortsInfo }: ShortsCardProps) => {
+  // mute를 store에서 통합 관리해서 다른 곳에서 음소거를 해제하면 계속 유지
+  const { isMuted, toggleMute } = useShortsVideoStore();
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const videoRef = useRef<HTMLVideoElement>(null);
 
@@ -16,18 +29,12 @@ const ShortsCard = ({ shortsInfo }: ShortsCardProps) => {
     alert("모달이 열립니다.");
   };
 
-  // 영상에 마우스 올리면 재생되도록 하는 거 만드는 중
-  // 근데 사용자 인터렉션 없이 재생하는 거 안 됨
-  // mute하면 해결할 수 있다.
-  // 이후 mute를 store에서 통합 관리해서 다른 곳에서 음소거를 해제하면 계속 유지되도록 하자.
-  // 미리보기는 전체는 아니고 5초 후에 멈추는 걸로 하자.
+  // 영상에 마우스 올리면 재생
   const hanldeMouseEnter = () => {
     videoRef.current?.play();
   };
 
   // 마우스를 떼면 0초로 돌아가는 기능 추가
-  const handleMouseLeave = () => pauseVideo();
-
   const pauseVideo = () => {
     const video = videoRef.current;
     if (video) {
@@ -37,18 +44,28 @@ const ShortsCard = ({ shortsInfo }: ShortsCardProps) => {
   };
 
   return (
-    <Card onClick={handleClick} onMouseEnter={hanldeMouseEnter} onMouseLeave={handleMouseLeave}>
+    <Card onMouseEnter={hanldeMouseEnter} onMouseLeave={pauseVideo}>
       {isLoading && <CardVideoSkeleton />}
-      <CardVideo
-        muted
-        src={shortsInfo.shortsLink}
-        crossOrigin="anonymous"
-        onLoadedData={() => setIsLoading(false)}
-        style={{ display: `${isLoading ? "none" : "inline"}` }}
-        ref={videoRef}
-      ></CardVideo>
-      <CardTitle>{shortsInfo.shortsTitle}</CardTitle>
-      <CardSubTitle>챌린저 {shortsInfo.shortsChallengers}명</CardSubTitle>
+      <CardVideoContainer>
+        <div onClick={handleClick}>
+          <CardVideo
+            muted={isMuted}
+            src={shortsInfo.shortsLink}
+            crossOrigin="anonymous"
+            onLoadedData={() => setIsLoading(false)}
+            style={{ display: `${isLoading ? "none" : "inline"}` }}
+            ref={videoRef}
+          ></CardVideo>
+        </div>
+        <Gradient />
+        <SoundButton className="hover-opacity" onClick={toggleMute}>
+          {isMuted ? <VolumeOffRounded /> : <VolumeUpRounded />}
+        </SoundButton>
+      </CardVideoContainer>
+      <div onClick={handleClick}>
+        <CardTitle>{shortsInfo.shortsTitle}</CardTitle>
+        <CardSubTitle>챌린저 {shortsInfo.shortsChallengers}명</CardSubTitle>
+      </div>
     </Card>
   );
 };

--- a/front/src/components/shorts/ShortsCard.tsx
+++ b/front/src/components/shorts/ShortsCard.tsx
@@ -45,14 +45,13 @@ const ShortsCard = ({ shortsInfo }: ShortsCardProps) => {
   return (
     <Card onMouseEnter={playVideo} onMouseLeave={pauseVideo}>
       {isLoading && <CardVideoSkeleton />}
-      <CardVideoContainer>
+      <CardVideoContainer style={{ display: `${isLoading ? "none" : "inline"}` }}>
         <div onClick={openModal}>
           <CardVideo
             muted={isMuted}
             src={shortsInfo.shortsLink}
             crossOrigin="anonymous"
             onLoadedData={() => setIsLoading(false)}
-            style={{ display: `${isLoading ? "none" : "inline"}` }}
             ref={videoRef}
           ></CardVideo>
         </div>

--- a/front/src/components/shorts/style.tsx
+++ b/front/src/components/shorts/style.tsx
@@ -7,13 +7,43 @@ export const Card = styled.div`
   cursor: pointer;
 `;
 
+export const CardVideoContainer = styled.div`
+  position: relative;
+
+  .hover-opacity {
+    opacity: 0;
+  }
+
+  &:hover {
+    .hover-opacity {
+      opacity: 1;
+    }
+  }
+`;
+
 export const CardVideo = styled.video`
   width: 100%;
   border-radius: 12px;
-  transition: border-radius 0.2s;
+`;
 
-  &:hover {
-    border-radius: 0;
+export const Gradient = styled.div`
+  position: absolute;
+  bottom: 5px;
+  width: 100%;
+  height: 100px;
+  background: rgb(0, 0, 0);
+  background: linear-gradient(transparent, rgba(0, 0, 0, 0.25));
+  border-radius: 0 0 12px 12px;
+`;
+
+export const SoundButton = styled.button`
+  position: absolute;
+  right: 12px;
+  bottom: 16px;
+  color: #fff;
+
+  svg {
+    font-size: 28px;
   }
 `;
 

--- a/front/src/components/shorts/style.tsx
+++ b/front/src/components/shorts/style.tsx
@@ -57,7 +57,7 @@ export const CardTitle = styled.div`
   overflow: hidden;
 `;
 
-export const CardSubTitle = styled.div`
+export const CardDesc = styled.div`
   font-size: 14px;
   color: #606060;
 `;

--- a/front/src/components/shorts/style.tsx
+++ b/front/src/components/shorts/style.tsx
@@ -10,6 +10,11 @@ export const Card = styled.div`
 export const CardVideo = styled.video`
   width: 100%;
   border-radius: 12px;
+  transition: border-radius 0.2s;
+
+  &:hover {
+    border-radius: 0;
+  }
 `;
 
 export const CardTitle = styled.div`

--- a/front/src/store/useShortsVideoStore.tsx
+++ b/front/src/store/useShortsVideoStore.tsx
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface ShortsVideoStore {
+  isMuted: boolean;
+  toggleMute: () => void;
+}
+
+const useShortsVideoStore = create<ShortsVideoStore>((set, get) => ({
+  isMuted: true,
+  toggleMute: () => set({ isMuted: !get().isMuted }),
+}));
+
+export default useShortsVideoStore;


### PR DESCRIPTION
## 요약
1. 메인페이지의 쇼츠 영상에 마우스를 놓으면 영상이 재생되는 기능을 구현했습니다.
    - 동적 재생을 위해 영상의 소리 설정이 음소거로 초기화되어 있습니다.
    - 호버 시 같이 나타나는 소리 토글 버튼을 통해 음소거를 취소할 수 있습니다.
    - 소리 설정은 모든 쇼츠 영상에서 공유됩니다. (음소거일 경우, 모든 영상이 음소거된 상태로 재생됨.)
    - 소리 설정은 `useShortsVideoStore.tsx`에서 관리합니다.

2. 메인페이지 쇼츠 그리드 값을 조정했습니다.
    - 기존보다 영상 콘텐츠를 더 크게 보여주기 위해 `GlobalStyle.tsx`에서 `--grid-items-per-row`의 값을 조정했습니다.
   
3.  주석, 컴포넌트 이름 등이 수정되었습니다.

## 이슈
쇼츠 그리드 값이 바뀜에 따라 무한 스크롤의 작동(탐지) 범위가 맞지 않는 문제를 발견했습니다.
기존에도 데스크톱에서만 정상 작동되는 문제가 있었기 때문에 다양한 환경에서도 유동적으로 작동할 수 있도록 수정해야 할 것 같습니다.

## 다음 계획
1. 무한 스크롤 문제 해결
2. 쇼츠 영상 클릭 시 열리는 모달창 개발