### PR TITLE
메인페이지의 영상에 섬네일 이미지를 추가했습니다.

### DIFF
--- a/front/src/components/shorts/ShortsCard.tsx
+++ b/front/src/components/shorts/ShortsCard.tsx
@@ -21,6 +21,7 @@ const ShortsCard = ({ shortsInfo, handleOpenModal }: ShortsCardProps) => {
     return arr[arr.length - 1];
   }, [shortsInfo.shortsUrl]);
 
+  // 영상에 마우스가 들어오면 영상 재생을 시작한다.
   const handleMouseOver = () => {
     if (!isLoading) {
       setShowThumbnail(false);
@@ -28,6 +29,7 @@ const ShortsCard = ({ shortsInfo, handleOpenModal }: ShortsCardProps) => {
     }
   };
 
+  // 영상에서 마우스를 떼면 재생된 영상을 초기화한다.
   const handleMouseOut = () => {
     if (!isLoading) {
       setShowThumbnail(true);
@@ -44,12 +46,10 @@ const ShortsCard = ({ shortsInfo, handleOpenModal }: ShortsCardProps) => {
     }
   };
 
-  // 영상에 마우스가 들어오면 영상 재생을 시작한다.
   const playVideo = () => {
     videoRef.current?.play();
   };
 
-  // 영상에서 마우스를 떼면 재생된 영상을 초기화한다.
   const pauseVideo = () => {
     const video = videoRef.current;
     if (video) {
@@ -65,7 +65,7 @@ const ShortsCard = ({ shortsInfo, handleOpenModal }: ShortsCardProps) => {
         <S.CardVideoBox onClick={openModal}>
           <S.Thumbnail
             src={`https://img.youtube.com/vi/${videoId}/frame0.jpg`}
-            alt=""
+            alt={`${shortsInfo.shortsTitle} 섬네일`}
             opacity={`${showThumbnail ? 1 : 0}`}
           />
           <S.CardVideo

--- a/front/src/components/shorts/ShortsCard.tsx
+++ b/front/src/components/shorts/ShortsCard.tsx
@@ -22,7 +22,7 @@ const ShortsCard = ({ shortsInfo, handleOpenModal }: ShortsCardProps) => {
   }, [shortsInfo.shortsUrl]);
 
   // 영상에 마우스가 들어오면 영상 재생을 시작한다.
-  const handleMouseOver = () => {
+  const handleMouseEnter = () => {
     if (!isLoading) {
       setShowThumbnail(false);
       playVideo();
@@ -30,7 +30,7 @@ const ShortsCard = ({ shortsInfo, handleOpenModal }: ShortsCardProps) => {
   };
 
   // 영상에서 마우스를 떼면 재생된 영상을 초기화한다.
-  const handleMouseOut = () => {
+  const handleMouseLeave = () => {
     if (!isLoading) {
       setShowThumbnail(true);
       pauseVideo();
@@ -59,9 +59,9 @@ const ShortsCard = ({ shortsInfo, handleOpenModal }: ShortsCardProps) => {
   };
 
   return (
-    <S.Card onMouseOver={handleMouseOver} onMouseOut={handleMouseOut}>
+    <S.Card onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
       {isLoading && <S.CardVideoSkeleton />}
-      <S.CardVideoContainer style={{ display: `${isLoading ? "none" : "inline"}` }}>
+      <S.CardVideoContainer style={{ display: `${isLoading ? "none" : "block"}` }}>
         <S.CardVideoBox onClick={openModal}>
           <S.Thumbnail
             src={`https://img.youtube.com/vi/${videoId}/frame0.jpg`}

--- a/front/src/components/shorts/ShortsCard.tsx
+++ b/front/src/components/shorts/ShortsCard.tsx
@@ -2,16 +2,7 @@ import { useRef, useState } from "react";
 import { VolumeUpRounded, VolumeOffRounded } from "@mui/icons-material";
 
 import useShortsVideoStore from "../../store/useShortsVideoStore";
-import {
-  Card,
-  CardVideo,
-  CardTitle,
-  CardDesc,
-  CardVideoSkeleton,
-  CardVideoContainer,
-  SoundButton,
-  Gradient,
-} from "./style";
+import * as S from "./style";
 import { Shorts } from "../../constants/types";
 
 interface ShortsCardProps {
@@ -78,40 +69,33 @@ const ShortsCard = ({ shortsInfo, handleOpenModal }: ShortsCardProps) => {
   };
 
   return (
-    <Card onMouseOver={handleMouseOver} onMouseOut={handleMouseOut}>
-      {isLoading && <CardVideoSkeleton />}
-      <CardVideoContainer style={{ display: `${isLoading ? "none" : "inline"}` }}>
-        <div onClick={openModal} style={{ width: "100%", aspectRatio: "9 / 16" }}>
-          {/* 썸네일 */}
-          <img
+    <S.Card onMouseOver={handleMouseOver} onMouseOut={handleMouseOut}>
+      {isLoading && <S.CardVideoSkeleton />}
+      <S.CardVideoContainer style={{ display: `${isLoading ? "none" : "inline"}` }}>
+        <S.CardVideoBox onClick={openModal}>
+          <S.Thumbnail
             src="https://img.youtube.com/vi/-jkcLE1Ticw/frame0.jpg"
             alt=""
-            style={{
-              position: "absolute",
-              zIndex: "1",
-              width: "100%",
-              borderRadius: "12px",
-              opacity: `${showThumbnail ? "1" : "0"}`,
-            }}
+            opacity={`${showThumbnail ? 1 : 0}`}
           />
-          <CardVideo
+          <S.CardVideo
             muted={isMuted}
             src={shortsInfo.shortsLink}
             crossOrigin="anonymous"
             onLoadedData={() => setIsLoading(false)}
             ref={videoRef}
-          ></CardVideo>
-        </div>
-        <Gradient />
-        <SoundButton className="hover-opacity" onClick={toggleMute}>
+          ></S.CardVideo>
+        </S.CardVideoBox>
+        <S.Gradient />
+        <S.SoundButton className="hover-opacity" onClick={toggleMute}>
           {isMuted ? <VolumeOffRounded /> : <VolumeUpRounded />}
-        </SoundButton>
-      </CardVideoContainer>
+        </S.SoundButton>
+      </S.CardVideoContainer>
       <div onClick={openModal}>
-        <CardTitle>{shortsInfo.shortsTitle}</CardTitle>
-        <CardDesc>챌린저 {shortsInfo.shortsChallengers}명</CardDesc>
+        <S.CardTitle>{shortsInfo.shortsTitle}</S.CardTitle>
+        <S.CardDesc>챌린저 {shortsInfo.shortsChallengers}명</S.CardDesc>
       </div>
-    </Card>
+    </S.Card>
   );
 };
 

--- a/front/src/components/shorts/ShortsCard.tsx
+++ b/front/src/components/shorts/ShortsCard.tsx
@@ -22,14 +22,46 @@ interface ShortsCardProps {
 const ShortsCard = ({ shortsInfo, handleOpenModal }: ShortsCardProps) => {
   const { isMuted, toggleMute } = useShortsVideoStore();
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [showThumbnail, setShowThumbnail] = useState<boolean>(true);
   const videoRef = useRef<HTMLVideoElement>(null);
+
+  const handleMouseOver = () => {
+    if (!isLoading) {
+      setShowThumbnail(false);
+      playVideo();
+    }
+  };
+
+  const handleMouseOut = () => {
+    if (!isLoading) {
+      setShowThumbnail(true);
+      pauseVideo();
+    }
+  };
 
   // 클릭했을 때 모달을 띄우기 위한 메소드
   // 모달을 띄울 때 영상을 멈추게 한다.
   const openModal = () => {
-    handleOpenModal();
-    pauseVideo();
+    if (!isLoading) {
+      handleOpenModal();
+      pauseVideo();
+    }
   };
+
+  /*
+    마우스를 떼면 영상을 초기화시키는 기능이 멈추기만하고 화면이 그 시간대에 머물러 있는 문제가 있음
+    로그를 통해 currentTime = 0 인 것을 확인했음
+    시간은 0으로 잘 움직였지만, 그 화면이 랜더링되지 않은 것으로 추측함
+
+    https://stackoverflow.com/questions/8402158/html5-video-javascript-controls-restart-video
+    이 글을 통해 load() 라는 메소드를 알게 되었음
+    사용하니 마우스를 떼면 영상이 멈추고 처음 화면이 잘 나타남
+    다만 그 과정에서 깜빡임이 발생함
+
+    역시 방법은 썸네일을 추가하는 것이다.
+    평소에는 img로 가려놓고, 마우스가 들어왔을 때만 img를 투명화시킨다.
+    마우스를 떼면 img를 다시 보여준다.
+  */
 
   // 영상에 마우스가 들어오면 영상 재생을 시작한다.
   const playVideo = () => {
@@ -46,10 +78,22 @@ const ShortsCard = ({ shortsInfo, handleOpenModal }: ShortsCardProps) => {
   };
 
   return (
-    <Card onMouseEnter={playVideo} onMouseLeave={pauseVideo}>
+    <Card onMouseOver={handleMouseOver} onMouseOut={handleMouseOut}>
       {isLoading && <CardVideoSkeleton />}
       <CardVideoContainer style={{ display: `${isLoading ? "none" : "inline"}` }}>
-        <div onClick={openModal}>
+        <div onClick={openModal} style={{ width: "100%", aspectRatio: "9 / 16" }}>
+          {/* 썸네일 */}
+          <img
+            src="https://img.youtube.com/vi/-jkcLE1Ticw/frame0.jpg"
+            alt=""
+            style={{
+              position: "absolute",
+              zIndex: "10",
+              width: "100%",
+              borderRadius: "12px",
+              opacity: `${showThumbnail ? "1" : "0"}`,
+            }}
+          />
           <CardVideo
             muted={isMuted}
             src={shortsInfo.shortsLink}

--- a/front/src/components/shorts/ShortsCard.tsx
+++ b/front/src/components/shorts/ShortsCard.tsx
@@ -39,21 +39,6 @@ const ShortsCard = ({ shortsInfo, handleOpenModal }: ShortsCardProps) => {
     }
   };
 
-  /*
-    마우스를 떼면 영상을 초기화시키는 기능이 멈추기만하고 화면이 그 시간대에 머물러 있는 문제가 있음
-    로그를 통해 currentTime = 0 인 것을 확인했음
-    시간은 0으로 잘 움직였지만, 그 화면이 랜더링되지 않은 것으로 추측함
-
-    https://stackoverflow.com/questions/8402158/html5-video-javascript-controls-restart-video
-    이 글을 통해 load() 라는 메소드를 알게 되었음
-    사용하니 마우스를 떼면 영상이 멈추고 처음 화면이 잘 나타남
-    다만 그 과정에서 깜빡임이 발생함
-
-    역시 방법은 썸네일을 추가하는 것이다.
-    평소에는 img로 가려놓고, 마우스가 들어왔을 때만 img를 투명화시킨다.
-    마우스를 떼면 img를 다시 보여준다.
-  */
-
   // 영상에 마우스가 들어오면 영상 재생을 시작한다.
   const playVideo = () => {
     videoRef.current?.play();

--- a/front/src/components/shorts/ShortsCard.tsx
+++ b/front/src/components/shorts/ShortsCard.tsx
@@ -88,7 +88,7 @@ const ShortsCard = ({ shortsInfo, handleOpenModal }: ShortsCardProps) => {
             alt=""
             style={{
               position: "absolute",
-              zIndex: "10",
+              zIndex: "1",
               width: "100%",
               borderRadius: "12px",
               opacity: `${showThumbnail ? "1" : "0"}`,

--- a/front/src/components/shorts/ShortsCard.tsx
+++ b/front/src/components/shorts/ShortsCard.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { VolumeUpRounded, VolumeOffRounded } from "@mui/icons-material";
 
 import useShortsVideoStore from "../../store/useShortsVideoStore";
@@ -15,6 +15,11 @@ const ShortsCard = ({ shortsInfo, handleOpenModal }: ShortsCardProps) => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [showThumbnail, setShowThumbnail] = useState<boolean>(true);
   const videoRef = useRef<HTMLVideoElement>(null);
+
+  const videoId = useMemo(() => {
+    const arr = shortsInfo.shortsUrl.split("/");
+    return arr[arr.length - 1];
+  }, [shortsInfo.shortsUrl]);
 
   const handleMouseOver = () => {
     if (!isLoading) {
@@ -59,7 +64,7 @@ const ShortsCard = ({ shortsInfo, handleOpenModal }: ShortsCardProps) => {
       <S.CardVideoContainer style={{ display: `${isLoading ? "none" : "inline"}` }}>
         <S.CardVideoBox onClick={openModal}>
           <S.Thumbnail
-            src="https://img.youtube.com/vi/-jkcLE1Ticw/frame0.jpg"
+            src={`https://img.youtube.com/vi/${videoId}/frame0.jpg`}
             alt=""
             opacity={`${showThumbnail ? 1 : 0}`}
           />

--- a/front/src/components/shorts/style.tsx
+++ b/front/src/components/shorts/style.tsx
@@ -9,6 +9,9 @@ export const Card = styled.div`
 
 export const CardVideoContainer = styled.div`
   position: relative;
+  width: 100%;
+  margin-bottom: 4px;
+  aspect-ratio: 9 / 16;
 
   .hover-opacity {
     opacity: 0;
@@ -28,7 +31,7 @@ export const CardVideo = styled.video`
 
 export const Gradient = styled.div`
   position: absolute;
-  bottom: 5px;
+  bottom: 0;
   width: 100%;
   height: 100px;
   background: rgb(0, 0, 0);
@@ -41,7 +44,7 @@ export const SoundButton = styled.button`
   right: 12px;
   bottom: 16px;
   color: #fff;
-  z-index: 2;
+  z-index: 1;
 
   svg {
     font-size: 28px;
@@ -86,14 +89,14 @@ export const CardSubTitleSkeleton = styled.div`
 
 export const CardVideoBox = styled.div`
   width: 100%;
-  aspect-ratio: "9 / 16";
+  height: 100%;
 `;
 
 export const Thumbnail = styled.img<{ opacity: string }>`
   position: absolute;
-  z-index: 1;
   width: 100%;
   border-radius: 12px;
+  z-index: 1;
   opacity: ${props => props.opacity};
   transition: opacity 0.2s;
 `;

--- a/front/src/components/shorts/style.tsx
+++ b/front/src/components/shorts/style.tsx
@@ -94,4 +94,5 @@ export const Thumbnail = styled.img<{ opacity: string }>`
   width: 100%;
   border-radius: 12px;
   opacity: ${props => props.opacity};
+  transition: opacity 0.2s;
 `;

--- a/front/src/components/shorts/style.tsx
+++ b/front/src/components/shorts/style.tsx
@@ -41,6 +41,7 @@ export const SoundButton = styled.button`
   right: 12px;
   bottom: 16px;
   color: #fff;
+  z-index: 2;
 
   svg {
     font-size: 28px;

--- a/front/src/components/shorts/style.tsx
+++ b/front/src/components/shorts/style.tsx
@@ -82,3 +82,16 @@ export const CardSubTitleSkeleton = styled.div`
   border-radius: 4px;
   background-color: #e2e2e6;
 `;
+
+export const CardVideoBox = styled.div`
+  width: 100%;
+  aspect-ratio: "9 / 16";
+`;
+
+export const Thumbnail = styled.img<{ opacity: string }>`
+  position: absolute;
+  z-index: 1;
+  width: 100%;
+  border-radius: 12px;
+  opacity: ${props => props.opacity};
+`;

--- a/front/src/pages/MainPage.tsx
+++ b/front/src/pages/MainPage.tsx
@@ -255,7 +255,7 @@ const Modal = styled.div`
   left: 50%;
   transform: translate(-50%, -50%);
   background-color: rgba(255, 255, 255, 0.8);
-  z-index: 1;
+  z-index: 10;
   padding: 20px;
   width: 50%;
   animation: ${pulse} 0.5s ease-in-out;


### PR DESCRIPTION
## 도입 배경
메인페이지에서 영상에 마우스를 놓으면 영상이 재생되고, 마우스를 떼면 영상이 멈추고 처음으로 돌아가는 기능이 있었습니다.
그러나 영상이 처음으로 돌아갈 때 화면에 그려지는 영상이 0초가 아닌 마우스를 뗀 순간의 화면으로 남아있었습니다.
로그로 확인한 결과, currentTime은 0으로 맞춰져 있었기 때문에 렌더링이 이루어지지 않아 발생한 문제라고 생각했습니다.
이후, 여러 시도를 통해 섬네일 이미지를 통해 영상의 모습을 가리는 것을 해결 방법으로 결정했습니다.

## 요약
1. 섬네일 이미지를 추가했습니다.
    - 이미지는 유튜브에서 제공하는 링크를 통해 동적으로 가지고 옵니다.
    - opacity 트랜지션을 추가했습니다.

2. 여러 버그 해결
    - 모달창이 섬네일 아래로 가려지는 문제를 해결했습니다.
    - 소리 버튼이 눌리지 않던 문제를 해결했습니다.
    - 카드 내에서 마우스를 이동시킬 때 영상이 끊기는 문제를 해결했습니다.

## 이슈

## 다음 계획
1. API `/api/shorts/{page}`의 파라미터를 통해 동적으로 사용할 수 있도록 수정
2. 연습 페이지 리펙토링 시작